### PR TITLE
fix android sdk target configuration typo

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -10,6 +10,6 @@
     <content src="index.html" />
     <plugin name="cordova-plugin-dialogs" spec="~2.0.1" />
     <platform name="android">
-      <preference name="android-targtSdkVersion" value="30" />
+      <preference name="android-targetSdkVersion" value="30" />
     </platform>
 </widget>


### PR DESCRIPTION
Unfortunately you had a typo in your configuration, so it built against SDK 29 by default and the problem did not occur.

